### PR TITLE
Fix link to LIst documentation

### DIFF
--- a/desktop.bundles/patterns/patterns.bemjson.js
+++ b/desktop.bundles/patterns/patterns.bemjson.js
@@ -125,6 +125,7 @@ module.exports = {
 														{
 															block: 'text',
 															mods: { view: 'link', size: 'l' },
+                                                            tag: 'a',
 															attrs: {
 																'href': 'https://github.com/whitepapertools/whitepaper-bem/blob/master/pt-list/pt-list.md'
 															},


### PR DESCRIPTION
На странице http://whitepaper.tools/patterns.html не работает ссылка "Посмотреть документацию" в блоке "LIst"

<img width="1114" alt="2018-08-12 15-34-33" src="https://user-images.githubusercontent.com/223620/44002050-4881509a-9e45-11e8-96f5-e1fbf1071b74.png">
